### PR TITLE
feat: add no_std + alloc support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,18 +5,24 @@ version = "1.4.3"
 authors = ["DarthSim <darthsim@gmail.com>"]
 edition = "2024"
 license-file = "LICENSE"
-repository="https://github.com/DarthSim/quantizr"
+repository = "https://github.com/DarthSim/quantizr"
 
 [lib]
 name = "quantizr"
+
+[dependencies]
+hashbrown = { version = "0.16.1", default-features = false }
+num-traits = { version = "0.2.19", default-features = false, features = ["libm"] }
+
+[features]
+default = ["std"]
+std = []
+capi = ["std"]
 
 [profile.release]
 opt-level = 3
 lto = true
 debug = false
 debug-assertions = false
-
-[features]
-"capi" = []
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -2,7 +2,7 @@
 name = "quantizr_demo"
 version = "0.0.1"
 authors = ["DarthSim <darthsim@gmail.com>"]
-edition = "2018"
+edition = "2024"
 license-file = "../LICENSE"
 
 [dependencies.quantizr]

--- a/src/capi.rs
+++ b/src/capi.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::missing_safety_doc)]
 
-use std::slice;
+use alloc::boxed::Box;
+use core::slice;
 
 use crate::error::Error;
 use crate::histogram::Histogram;
@@ -17,7 +18,7 @@ pub enum QuantizrError {
     QuantizrBufferTooSmall = 1,
 }
 
-impl std::convert::From<Error> for QuantizrError {
+impl From<Error> for QuantizrError {
     fn from(error: Error) -> Self {
         match error {
             Error::ValueOutOfRange => Self::QuantizrValueOutOfRange,
@@ -131,20 +132,20 @@ pub unsafe extern "C" fn quantizr_remap(
 
 #[unsafe(no_mangle)]
 pub extern "C" fn quantizr_free_result(result: Box<QuantizeResult>) {
-    std::mem::drop(result)
+    drop(result)
 }
 
 #[unsafe(no_mangle)]
 pub extern "C" fn quantizr_free_histogram(hist: Box<Histogram>) {
-    std::mem::drop(hist)
+    drop(hist)
 }
 
 #[unsafe(no_mangle)]
 pub extern "C" fn quantizr_free_image(image: Box<Image>) {
-    std::mem::drop(image)
+    drop(image)
 }
 
 #[unsafe(no_mangle)]
 pub extern "C" fn quantizr_free_options(options: Box<Options>) {
-    std::mem::drop(options)
+    drop(options)
 }

--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -1,3 +1,7 @@
+use alloc::vec::Vec;
+#[cfg(not(feature = "std"))]
+use num_traits::Float;
+
 use crate::ord_float::OrdFloat32;
 
 use crate::histogram::{Histogram, HistogramEntry};
@@ -186,7 +190,7 @@ impl<'clust> Cluster<'clust> {
 #[inline(always)]
 fn add_color(dst: &mut [f32; 4], src: &[f32; 4], weight: f32) {
     unsafe {
-        use std::arch::x86_64::*;
+        use core::arch::x86_64::*;
 
         let mut psrc = _mm_loadu_ps(src.as_ptr());
         let mut pdst = _mm_loadu_ps(dst.as_ptr());
@@ -203,7 +207,7 @@ fn add_color(dst: &mut [f32; 4], src: &[f32; 4], weight: f32) {
 #[inline(always)]
 fn add_color(dst: &mut [f32; 4], src: &[f32; 4], weight: f32) {
     unsafe {
-        use std::arch::aarch64::*;
+        use core::arch::aarch64::*;
 
         let mut psrc = vld1q_f32(src.as_ptr());
         let mut pdst = vld1q_f32(dst.as_ptr());
@@ -232,7 +236,7 @@ fn add_color(dst: &mut [f32; 4], src: &[f32; 4], weight: f32) {
 #[inline(always)]
 fn add_diff(dst: &mut [f32; 4], a: &[f32; 4], b: &[f32; 4], weight: f32) {
     unsafe {
-        use std::arch::x86_64::*;
+        use core::arch::x86_64::*;
 
         let pa = _mm_loadu_ps(a.as_ptr());
         let pb = _mm_loadu_ps(b.as_ptr());
@@ -256,7 +260,7 @@ fn add_diff(dst: &mut [f32; 4], a: &[f32; 4], b: &[f32; 4], weight: f32) {
 #[inline(always)]
 fn add_diff(dst: &mut [f32; 4], a: &[f32; 4], b: &[f32; 4], weight: f32) {
     unsafe {
-        use std::arch::aarch64::*;
+        use core::arch::aarch64::*;
 
         let pa = vld1q_f32(a.as_ptr());
         let pb = vld1q_f32(b.as_ptr());

--- a/src/colormap.rs
+++ b/src/colormap.rs
@@ -1,3 +1,7 @@
+use alloc::vec::Vec;
+#[cfg(not(feature = "std"))]
+use num_traits::Float;
+
 use crate::ord_float::OrdFloat32;
 
 use crate::vpsearch;
@@ -180,7 +184,7 @@ fn sort_colors(entries: &mut [[f32; 4]], weights: &mut [f32]) {
 #[inline(always)]
 fn add_color(dst: &mut [f32; 4], src: &[f32; 4], weight: f32) {
     unsafe {
-        use std::arch::x86_64::*;
+        use core::arch::x86_64::*;
 
         let mut psrc = _mm_loadu_ps(src.as_ptr());
         let mut pdst = _mm_loadu_ps(dst.as_ptr());
@@ -197,7 +201,7 @@ fn add_color(dst: &mut [f32; 4], src: &[f32; 4], weight: f32) {
 #[inline(always)]
 fn add_color(dst: &mut [f32; 4], src: &[f32; 4], weight: f32) {
     unsafe {
-        use std::arch::aarch64::*;
+        use core::arch::aarch64::*;
 
         let mut psrc = vld1q_f32(src.as_ptr());
         let mut pdst = vld1q_f32(dst.as_ptr());

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,4 @@
-use std::fmt;
+use core::fmt;
 
 #[non_exhaustive]
 pub enum Error {
@@ -23,4 +23,4 @@ impl fmt::Debug for Error {
     }
 }
 
-impl std::error::Error for Error {}
+impl core::error::Error for Error {}

--- a/src/histogram.rs
+++ b/src/histogram.rs
@@ -1,5 +1,9 @@
+use core::hash::{BuildHasher, Hasher};
+
+#[cfg(feature = "std")]
 use std::collections::HashMap;
-use std::hash::{BuildHasher, Hasher};
+#[cfg(not(feature = "std"))]
+use hashbrown::HashMap;
 
 use crate::image::Image;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,8 @@
 //! Fast library for conversion of RGBA images to 8-bit paletted images.
 //!
+//! This crate supports `no_std` environments with the `alloc` crate.
+//! Disable the default `std` feature to use in `no_std` mode.
+//!
 //! ### Quantizing an image
 //!
 //! ```
@@ -53,6 +56,10 @@
 //! save_image1(palette, indexes1, width1, height1);
 //! save_image2(palette, indexes2, width2, height2);
 //! ```
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+extern crate alloc;
 
 mod cluster;
 mod colormap;

--- a/src/ord_float.rs
+++ b/src/ord_float.rs
@@ -1,4 +1,4 @@
-use std::cmp::Ordering;
+use core::cmp::Ordering;
 
 #[derive(Debug, Copy, Clone)]
 #[repr(transparent)]

--- a/src/palette.rs
+++ b/src/palette.rs
@@ -1,3 +1,6 @@
+#[cfg(not(feature = "std"))]
+use num_traits::Float;
+
 /// RGBA color
 #[repr(C)]
 #[derive(Clone, Copy, Default)]

--- a/src/quantize.rs
+++ b/src/quantize.rs
@@ -1,3 +1,6 @@
+use alloc::vec;
+use core::mem;
+
 use crate::cluster::Cluster;
 use crate::colormap::Colormap;
 use crate::error::Error;
@@ -200,7 +203,7 @@ impl QuantizeResult {
                 err[3] += err_a * 7.0;
             }
 
-            std::mem::swap(&mut error_curr, &mut error_next);
+            mem::swap(&mut error_curr, &mut error_next);
             error_next.fill_with(|| [0f32; 4]);
         }
     }

--- a/src/vpsearch.rs
+++ b/src/vpsearch.rs
@@ -1,3 +1,8 @@
+use alloc::boxed::Box;
+use alloc::vec::Vec;
+#[cfg(not(feature = "std"))]
+use num_traits::Float;
+
 use crate::ord_float::OrdFloat32;
 
 #[derive(Clone)]
@@ -115,19 +120,19 @@ impl SearchNode {
             if let Some(near) = &self.near {
                 near.visit(pin, nearest);
             }
-            if distance_sq.sqrt() >= self.radius - nearest.distance {
-                if let Some(far) = &self.far {
-                    far.visit(pin, nearest);
-                }
+            if distance_sq.sqrt() >= self.radius - nearest.distance
+                && let Some(far) = &self.far
+            {
+                far.visit(pin, nearest);
             }
         } else {
             if let Some(far) = &self.far {
                 far.visit(pin, nearest);
             }
-            if distance_sq.sqrt() <= self.radius + nearest.distance {
-                if let Some(near) = &self.near {
-                    near.visit(pin, nearest);
-                }
+            if distance_sq.sqrt() <= self.radius + nearest.distance
+                && let Some(near) = &self.near
+            {
+                near.visit(pin, nearest);
             }
         }
     }
@@ -177,7 +182,7 @@ impl SearchTree {
 #[inline(always)]
 fn dist(c1: &[f32; 4], c2: &[f32; 4]) -> f32 {
     unsafe {
-        use std::arch::x86_64::*;
+        use core::arch::x86_64::*;
 
         let pc1 = _mm_loadu_ps(c1.as_ptr());
         let pc2 = _mm_loadu_ps(c2.as_ptr());
@@ -196,7 +201,7 @@ fn dist(c1: &[f32; 4], c2: &[f32; 4]) -> f32 {
 #[inline(always)]
 fn dist(c1: &[f32; 4], c2: &[f32; 4]) -> f32 {
     unsafe {
-        use std::arch::aarch64::*;
+        use core::arch::aarch64::*;
 
         let pc1 = vld1q_f32(c1.as_ptr());
         let pc2 = vld1q_f32(c2.as_ptr());


### PR DESCRIPTION
Adds `no_std + alloc` support for embedded/WASM use cases.

Closes #2

## Changes

- Add `#![cfg_attr(not(feature = "std"), no_std)]` for conditional no_std
- Use `hashbrown::HashMap` in no_std mode (std uses `std::collections::HashMap`)  
- Add `num-traits` with libm feature for f32 math methods in no_std
- Replace `std::arch` → `core::arch` for SIMD intrinsics
- Replace `std::cmp`, `std::fmt`, `std::hash`, `std::mem`, `std::slice` → `core::*`
- Use `core::error::Error` (stable since Rust 1.81)
- Feature-gate `num_traits::Float` import for no_std only
- Fix pre-existing `collapsible_if` clippy warnings in vpsearch.rs

## Usage

```toml
# Default (std) - unchanged
quantizr = "1.4.3"

# no_std + alloc  
quantizr = { version = "1.4.3", default-features = false }
```

## Testing

- Builds on `thumbv7em-none-eabihf` (no_std target)
- All existing tests pass
- Clippy clean with `-D warnings`